### PR TITLE
Build on Mac OS 10.9 by using libkern/OSByteOrder.h

### DIFF
--- a/fwcutter/fwcutter.c
+++ b/fwcutter/fwcutter.c
@@ -40,6 +40,8 @@
 
 #if defined(__DragonFly__) || defined(__FreeBSD__)
 #include <sys/endian.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
 #else
 #include <byteswap.h>
 #endif

--- a/fwcutter/fwcutter.h
+++ b/fwcutter/fwcutter.h
@@ -20,6 +20,9 @@ typedef uint32_t le32_t; /* Little-endian 32bit */
 #if defined(__DragonFly__) || defined(__FreeBSD__)
 #define bswap_16	bswap16
 #define bswap_32	bswap32
+#elif defined(__APPLE__)
+#define bswap_16	OSSwapInt16
+#define bswap_32	OSSwapInt32
 #endif
 
 #define ARG_MATCH	0


### PR DESCRIPTION
Tested on OS 10.9.1. Extracted the firmware from `broadcom-wl-5.100.138` successfully and used it for a Debian installation.
