### PR TITLE
Added script to prepare bcm43438 ucode for disassembling

### DIFF
--- a/debug/ucode_write_byte.pl
+++ b/debug/ucode_write_byte.pl
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+=pod
+This script can be used to rearrange the ucode found in the bcm43438 to enable disassembling
+The '-r' parameter can be used to reverse this process
+=cut
+
+my $buffer;
+my @bytes = ();
+my $cnt = 0;
+my $reverse = 0;
+my $infile;
+my $outfile;
+
+my $num_args = $#ARGV + 1;
+if ($num_args < 2) {
+print "Usage: [-r] in_file out_file\n";
+    exit;
+}
+
+if($ARGV[0] =~ '-r') {
+    $reverse = 1;
+    $infile = $ARGV[1];
+    $outfile = $ARGV[2];
+} else {
+    $infile = $ARGV[0];
+    $outfile = $ARGV[1];
+}
+
+print("Using infile: '$infile', outfile: '$outfile'\n");
+# File size of $infile
+my $ucode_len = -s $infile;
+
+open(FH, '<:raw', $infile);
+read(FH, $buffer, $ucode_len);
+@bytes = unpack('C*',$buffer); # 'C*' multiple unsigned character
+close(FH);
+
+open(FHW, '>:raw', $outfile);
+if(not $reverse) {
+    while($cnt < $ucode_len) {
+        $cnt += 7;
+        my $byte1 = ($bytes[$cnt-3] << 16) | ($bytes[$cnt-4] << 24) | ($bytes[$cnt-1]) | ($bytes[$cnt-2] << 8);
+        print FHW pack('I', $byte1); # 'I' 32 bit unsigned int
+        my $byte2 = ($bytes[$cnt-6] << 8) | ($bytes[$cnt-7] << 16) | ($bytes[$cnt-5]);
+        print FHW pack('I', $byte2);
+    }
+} else {
+    while($cnt < $ucode_len) {
+        $cnt += 8;
+        my $byte1 = sprintf("%014x", ($bytes[$cnt-2] << 48) | ($bytes[$cnt-3] << 40) | ($bytes[$cnt-4] << 32) | ($bytes[$cnt-5] << 24) | ($bytes[$cnt-6] << 16) | ($bytes[$cnt-7] << 8) | ($bytes[$cnt-8]));
+        print FHW pack('H*', $byte1); # 'H*' hex string (high nybble first)
+    }
+}
+close(FHW);


### PR DESCRIPTION
The format of the bcm43438 ucode used in the Raspberry Pi 3 needs preparation before it can be disassembled. This is handled in the ARM firmware before copying the code to the d11 core.

With this script I was able to disassemble bcm43438 ucode. During disassembling I got the following Warnings:

```
Disassembler warning:
  NAP: invalid first argument 0x0000

Disassembler warning:
  NAP: invalid second argument 0x0000

Disassembler warning:
  NAP: invalid first argument 0x0000

Disassembler warning:
  NAP: invalid second argument 0x0000

Disassembler warning:
  NAP: invalid first argument 0x0000

Disassembler warning:
  NAP: invalid second argument 0x0000
```

I was also able to assemble the resulting code back to a binary and using the script to get the code back to the original binary representation. Despite the missing argument for the  _NAP_ instruction, the reassembled code runs fine on the Rapsberry Pi 3.
