### PR TITLE
fix format warning in compilation

### DIFF
--- a/ssb_sprom/ssb_sprom.c
+++ b/ssb_sprom/ssb_sprom.c
@@ -678,9 +678,9 @@ static void print_banner(int forceprint)
 			  "Be exceedingly careful with this tool. Improper"
 			  " usage WILL BRICK YOUR DEVICE.\n";
 	if (forceprint)
-		prdata(str);
+		prdata("%s", str);
 	else
-		prinfo(str);
+		prinfo("%s", str);
 }
 
 static void print_usage(int argc, char *argv[])


### PR DESCRIPTION
fix: ssb_sprom.c:681:3: warning: format not a string literal and no format arguments [-Wformat-security]