### PR TITLE
replace custom bool typedef with <stdbool.h>

### DIFF
--- a/assembler/util.h
+++ b/assembler/util.h
@@ -1,6 +1,7 @@
 #ifndef BCM43xx_ASM_UTIL_H_
 #define BCM43xx_ASM_UTIL_H_
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -21,8 +22,6 @@ void dump(const char *data,
 void * xmalloc(size_t size);
 char * xstrdup(const char *str);
 
-
-typedef _Bool bool;
 
 typedef uint16_t be16_t;
 typedef uint32_t be32_t;

--- a/disassembler/util.h
+++ b/disassembler/util.h
@@ -1,6 +1,7 @@
 #ifndef BCM43xx_DASM_UTIL_H_
 #define BCM43xx_DASM_UTIL_H_
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -16,8 +17,6 @@ void dump(const char *data,
 void * xmalloc(size_t size);
 char * xstrdup(const char *str);
 void * xrealloc(void *in, size_t size);
-
-typedef _Bool bool;
 
 typedef uint32_t be32_t;
 


### PR DESCRIPTION
The build fails under C23 with the following error in util.h:
  util.h:25:15: error: 'bool' cannot be defined via 'typedef'
     25 | typedef _Bool bool;
        |               ^~~~

This patch removes the manual typedef of `_Bool` to `bool` and includes `<stdbool.h>` instead.