### PR TITLE
b43-asm: fix undefined behavior by using unsigned shift

### DIFF
--- a/assembler/main.c
+++ b/assembler/main.c
@@ -216,7 +216,7 @@ static bool is_valid_imm(struct assembler_context *ctx,
 
 	/* First create a mask with all possible bits for
 	 * an immediate value unset. */
-	mask = (~0 << immediate_size) & 0xFFFF;
+	mask = (~0U << immediate_size) & 0xFFFF;
 	/* Is the sign bit of the immediate set? */
 	if (imm & (1 << (immediate_size - 1))) {
 		/* Yes, so all bits above that must also


### PR DESCRIPTION
Replace `~0` with `~0U` to avoid left-shifting a signed negative value.

Fixes warning:
```
main.c: In function ‘is_valid_imm’:
main.c:219:20: warning: left shift of negative value [-Wshift-negative-value]
  219 |         mask = (~0 << immediate_size) & 0xFFFF;
      |                    ^~
     CC       obj/parser.o

```